### PR TITLE
Correct blockchain volume and entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN apt-get update && \
 COPY --from=builder /src/build/release/bin/* /usr/local/bin/
 
 # Contains the blockchain
-VOLUME /root/.bitmonero
+VOLUME /root/.monerov
 
 # Generate your wallet via accessing the container and run:
 # cd /wallet
@@ -114,4 +114,4 @@ VOLUME /wallet
 EXPOSE 19090
 EXPOSE 19091
 
-ENTRYPOINT ["monerod", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=19090", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=19091", "--non-interactive", "--confirm-external-bind"] 
+ENTRYPOINT ["monerovd", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=19090", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=19091", "--non-interactive", "--confirm-external-bind"] 


### PR DESCRIPTION
The volume is not /root/.bitmonero it is /root/.monerov
Otherwise the full-node in the container runs out of memory as it is capped to 10gb

The entrypoint is not monerod it is monerovd
Otherwise the container wont start without --entrypoint arguments

```
git clone --recursive https://github.com/monerov/monerov.git
cd monerov
docker build . -t monerovd
mount /dev/mapper/vg0-lvwithatleast40gb /blockchain-xmv
docker run \
  --restart=always \
  -v /blockchain-xmv:/root/.monerov \
  -e LOG_LEVEL=0 \
  --network=host --name=monerovd \
  --entrypoint /usr/local/bin/monerovd \
  -td \
  monerovd \
  --p2p-bind-ip=0.0.0.0 --p2p-bind-port=19090 --rpc-bind-ip=0.0.0.0 --rpc-bind-port=19091 \
  --non-interactive --confirm-external-bind \
  --restricted-rpc 
```